### PR TITLE
fix(keymapping): get the function of ~ back

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -75,7 +75,7 @@ require 'nvim-treesitter.configs'.setup {
     swap = {
       enable = true,
       swap_next = {
-        ["~"] = "@parameter.inner",
+        ["+"] = "@parameter.inner",
       },
     },
   },


### PR DESCRIPTION
- it was mapped to some function of treesitter, which I didn't use and I really liked the old behaviour.